### PR TITLE
changes to fhir consent doc regarding versioning

### DIFF
--- a/docs/pages/technical/fhir-rules.rst
+++ b/docs/pages/technical/fhir-rules.rst
@@ -146,7 +146,7 @@ Source
 ......
 
 The :code:`source` will always be an :code:`sourceAttachment`. The source always points to the latest change in consent proof.
-The attachment can have a :code:`contentType` and must have an :code:`url`. There are several valid contentTypes:
+The attachment can have a :code:`contentType` and can have an :code:`url`. There are several valid contentTypes:
 
 - application/pdf
 - application/json+irma
@@ -156,6 +156,7 @@ When the source is of type **application/json+irma**, the data is the login cont
 The title should reflect the type of consent given. Since no personal data is stored, the source only refers to a proof.
 The :code:`url` must be accessible and must accept a Nuts identification method (eg: Irma signature in a JWT).
 The hash can proof the document has not been tempered with.
+Initially the title will be the most important, when no online reference is available through an url, the title will be the reference clients/patients will use to contact the care organisation.
 
 .. code-block:: json
 

--- a/docs/pages/technical/fhir-rules.rst
+++ b/docs/pages/technical/fhir-rules.rst
@@ -43,6 +43,7 @@ Additional rules
 
 In order for the Nuts components to use the consent records for validation, additional properties are required:
 
+- :code:`meta` is required
 - :code:`patient` is required and refers to a patient.
 - :code:`dateTime` is required
 - :code:`performer` is optional and refers to the user recording the consent.
@@ -53,6 +54,14 @@ In order for the Nuts components to use the consent records for validation, addi
 - :code:`provision` is required and defines the extend of the consent.
 
 Each complex requirement is explained in sub sections.
+
+Meta
+....
+
+The :code:`meta` field is used to track changes to the consent and might indicate there are previous versions. Only the latest consent proof will be referenced form the active document.
+If a later proof constrains the active consent, eg: end it on a specific date. Then the latest proof will point to the document proving the consent has ended.
+The :code:`meta` field will then indicate that the current record has a :code:`versionId > 1`. Previous records will still contain the proof wht consent has been given in the past.
+The :code:`versionId` field starts at :code:`1` and is incremented with `1` for each update. The :code:`lastUpdated` field is also required and will indicate the last moment the record was updated.
 
 Patient
 .......
@@ -136,8 +145,8 @@ Organization
 Source
 ......
 
-The :code:`source` will always be an :code:`sourceAttachment`. The attachment must have a :code:`contentType` and must have an :code:`url`.
-There are several valid contentTypes:
+The :code:`source` will always be an :code:`sourceAttachment`. The source always points to the latest change in consent proof.
+The attachment can have a :code:`contentType` and must have an :code:`url`. There are several valid contentTypes:
 
 - application/pdf
 - application/json+irma

--- a/examples/minimal_consent.json
+++ b/examples/minimal_consent.json
@@ -1,5 +1,9 @@
 {
   "resourceType": "Consent",
+  "meta": {
+    "versionId": "1",
+    "lastUpdated": "2015-02-07T13:28:17.239+02:00"
+  },
   "scope": {
     "coding": [
       {

--- a/examples/observation_consent.json
+++ b/examples/observation_consent.json
@@ -1,5 +1,9 @@
 {
   "resourceType": "Consent",
+  "meta": {
+    "versionId": "1",
+    "lastUpdated": "2015-02-07T13:28:17.239+02:00"
+  },
   "scope": {
     "coding": [
       {

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.5
+	github.com/stretchr/testify v1.4.0
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xeipuuv/gojsonschema v1.1.0

--- a/pkg/validation.go
+++ b/pkg/validation.go
@@ -97,6 +97,10 @@ func PeriodFrom(jsonq *gojsonq.JSONQ) []time.Time {
 	return []time.Time{start, end}
 }
 
+func VersionFrom(jsonq *gojsonq.JSONQ) string {
+	return jsonq.Copy().Find("meta.versionId").(string)
+}
+
 // SubjectFrom extracts the patient from a given Consent json jsonq source
 func SubjectFrom(jsonq *gojsonq.JSONQ) string {
 	patientIdentifier := fmt.Sprintf(concatIdFormat,

--- a/pkg/validation_test.go
+++ b/pkg/validation_test.go
@@ -20,6 +20,7 @@
 package pkg
 
 import (
+	"github.com/stretchr/testify/assert"
 	"gopkg.in/thedevsaddam/gojsonq.v2"
 	"io/ioutil"
 	"testing"
@@ -99,4 +100,11 @@ func TestPeriodFrom(t *testing.T) {
 	if got[0].Minute() != 2 || got[1].Minute() != 32 {
 		t.Errorf("PeriodFrom() = %v, want %v", got, want)
 	}
+}
+
+func TestVersionFrom(t *testing.T) {
+	bytes, _ := ioutil.ReadFile("../examples/observation_consent.json")
+	jsonq := gojsonq.New().JSONString(string(bytes))
+
+	assert.Equal(t, "1", VersionFrom(jsonq))
 }


### PR DESCRIPTION
Proposal for tracking changes and versions. Older versions are still stored in the private chain for each consent record and are thus retrievable.

Signed-off-by: Wout Slakhorst <wout.slakhorst@nedap.com>