### PR TITLE
Extract data classes from fhir with system and code

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -21,12 +21,15 @@ package api
 
 import (
 	"bytes"
-	"github.com/golang/mock/gomock"
-	"github.com/nuts-foundation/nuts-fhir-validation/pkg"
-	"github.com/nuts-foundation/nuts-go-core/mock"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/nuts-foundation/nuts-fhir-validation/pkg"
+	core "github.com/nuts-foundation/nuts-go-core"
+	"github.com/nuts-foundation/nuts-go-core/mock"
 )
 
 func TestDefaultValidationBackend_Validate(t *testing.T) {
@@ -96,7 +99,7 @@ func validationResult() ValidationResponse {
 		Consent: &SimplifiedConsent{
 			Actors:    []Identifier{"urn:oid:2.16.840.1.113883.2.4.6.1:00000007"},
 			Custodian: Identifier("urn:oid:2.16.840.1.113883.2.4.6.1:00000000"),
-			Resources: []string{"http://hl7.org/fhir/resource-types#Observation","urn:oid:1.3.6.1.4.1.54851.1:MEDICAL"},
+			Resources: []string{"http://hl7.org/fhir/resource-types#Observation", fmt.Sprintf("%s:MEDICAL", core.NutsConsentClassesOID)},
 			Subject:   Identifier("urn:oid:2.16.840.1.113883.2.4.6.3:999999990"),
 		},
 		Outcome: "valid",

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -99,7 +99,7 @@ func validationResult() ValidationResponse {
 		Consent: &SimplifiedConsent{
 			Actors:    []Identifier{"urn:oid:2.16.840.1.113883.2.4.6.1:00000007"},
 			Custodian: Identifier("urn:oid:2.16.840.1.113883.2.4.6.1:00000000"),
-			Resources: []string{"http://hl7.org/fhir/resource-types#Observation", fmt.Sprintf("%s:MEDICAL", core.NutsConsentClassesOID)},
+			Resources: []string{"http://hl7.org/fhir/resource-types#Observation", fmt.Sprintf("urn:oid:%s:MEDICAL", core.NutsConsentClassesOID)},
 			Subject:   Identifier("urn:oid:2.16.840.1.113883.2.4.6.3:999999990"),
 		},
 		Outcome: "valid",

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -96,7 +96,7 @@ func validationResult() ValidationResponse {
 		Consent: &SimplifiedConsent{
 			Actors:    []Identifier{"urn:oid:2.16.840.1.113883.2.4.6.1:00000007"},
 			Custodian: Identifier("urn:oid:2.16.840.1.113883.2.4.6.1:00000000"),
-			Resources: []string{"Observation"},
+			Resources: []string{"http://hl7.org/fhir/resource-types#Observation","urn:oid:1.3.6.1.4.1.54851.1:MEDICAL"},
 			Subject:   Identifier("urn:oid:2.16.840.1.113883.2.4.6.3:999999990"),
 		},
 		Outcome: "valid",

--- a/examples/observation_consent.json
+++ b/examples/observation_consent.json
@@ -108,6 +108,10 @@
           {
             "system": "http://hl7.org/fhir/resource-types",
             "code": "Observation"
+          },
+          {
+            "system": "urn:oid:1.3.6.1.4.1.54851.1",
+            "code": "MEDICAL"
           }
         ]
       }

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/magiconair/properties v1.8.1 // indirect
 	github.com/mattn/go-colorable v0.1.4 // indirect
 	github.com/mattn/go-isatty v0.0.10 // indirect
-	github.com/nuts-foundation/nuts-go-core v0.0.0-20191028170600-66675906a53a
+	github.com/nuts-foundation/nuts-go-core v0.0.0-20191218133145-27ebcf628fab
 	github.com/pelletier/go-toml v1.5.0 // indirect
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/cobra v0.0.5

--- a/go.sum
+++ b/go.sum
@@ -97,6 +97,8 @@ github.com/nuts-foundation/nuts-go-core v0.0.0-20191014142450-dd0fd3a25ffb h1:Sd
 github.com/nuts-foundation/nuts-go-core v0.0.0-20191014142450-dd0fd3a25ffb/go.mod h1:tPPkfE9y+T+jTc8klZ0B8FXtc23p9NIpg5BjI+FIiEs=
 github.com/nuts-foundation/nuts-go-core v0.0.0-20191028170600-66675906a53a h1:0r1YHKAMSiP6yFy322lNclOU53LVfdkuRFsdQBJ/NU0=
 github.com/nuts-foundation/nuts-go-core v0.0.0-20191028170600-66675906a53a/go.mod h1:+IeGzu5J8qlF4Jcol+mY+MRcLDIfJ8OQnQV4wDp887o=
+github.com/nuts-foundation/nuts-go-core v0.0.0-20191218133145-27ebcf628fab h1:Dxjdaw+HToUVmh2H1/pg+BFNzNWm72bqVlA3LqcCiGs=
+github.com/nuts-foundation/nuts-go-core v0.0.0-20191218133145-27ebcf628fab/go.mod h1:+IeGzu5J8qlF4Jcol+mY+MRcLDIfJ8OQnQV4wDp887o=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/pkg/validation_test.go
+++ b/pkg/validation_test.go
@@ -20,11 +20,14 @@
 package pkg
 
 import (
-	"github.com/stretchr/testify/assert"
-	"gopkg.in/thedevsaddam/gojsonq.v2"
+	"fmt"
 	"io/ioutil"
 	"testing"
 	"time"
+
+	core "github.com/nuts-foundation/nuts-go-core"
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/thedevsaddam/gojsonq.v2"
 )
 
 func TestDefaultValidationBackend_ValidateAgainstSchema(t *testing.T) {
@@ -98,7 +101,7 @@ func TestResourcesFrom(t *testing.T) {
 	})
 
 	t.Run("with urn", func(t *testing.T) {
-		assert.Equal(t, "urn:oid:1.3.6.1.4.1.54851.1:MEDICAL", dataClasses[1])
+		assert.Equal(t, fmt.Sprintf("%s:MEDICAL", core.NutsConsentClassesOID), dataClasses[1])
 	})
 }
 

--- a/pkg/validation_test.go
+++ b/pkg/validation_test.go
@@ -88,6 +88,20 @@ func validationBackend() Validator {
 	return client
 }
 
+func TestResourcesFrom(t *testing.T) {
+	bytes, _ := ioutil.ReadFile("../examples/observation_consent.json")
+	jsonq := gojsonq.New().JSONString(string(bytes))
+	dataClasses := ResourcesFrom(jsonq)
+
+	t.Run("with namespace", func(t *testing.T) {
+		assert.Equal(t, "http://hl7.org/fhir/resource-types#Observation", dataClasses[0])
+	})
+
+	t.Run("with urn", func(t *testing.T) {
+		assert.Equal(t, "urn:oid:1.3.6.1.4.1.54851.1:MEDICAL", dataClasses[1])
+	})
+}
+
 func TestPeriodFrom(t *testing.T) {
 	//"start": "2016-06-23T17:02:33+10:00",
 	//"end": "2016-06-23T17:32:33+10:00"

--- a/pkg/validation_test.go
+++ b/pkg/validation_test.go
@@ -101,7 +101,7 @@ func TestResourcesFrom(t *testing.T) {
 	})
 
 	t.Run("with urn", func(t *testing.T) {
-		assert.Equal(t, fmt.Sprintf("%s:MEDICAL", core.NutsConsentClassesOID), dataClasses[1])
+		assert.Equal(t, fmt.Sprintf("urn:oid:%s:MEDICAL", core.NutsConsentClassesOID), dataClasses[1])
 	})
 }
 


### PR DESCRIPTION
Only the code is currently extracted resulting in incorrect storage of the consent records in the store. This PR will also extract the system, it determines the divider in the resulting string based on the system. Namespace types get a # and urn types a :.

Fixes #8

Signed-off-by: Wout Slakhorst <wout.slakhorst@nedap.com>